### PR TITLE
Update keywords for Gatsby Plugin Library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "gatsby-source-itchio",
   "version": "0.1.1",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin"
+  ],
   "description": "A GatsbyJS source plugin for itch.io",
   "scripts": {
     "build": "babel src --out-dir .",


### PR DESCRIPTION
Hi there!

I noticed that your `package.json` was missing the keyword `gatsby-plugin`. This keyword will enable this plugin to be included in the Gatsby Plugin Library. You can check [Gatsby's documentation](https://www.gatsbyjs.org/contributing/submit-to-plugin-library/) on how plugins are added.

cc: [Gatsby PR](https://github.com/gatsbyjs/gatsby/issues/14013) for more information about the plugin.